### PR TITLE
Add feels-like temperature sensor (UTCI via pythermalcomfort)

### DIFF
--- a/custom_components/nl_weather/binary_sensor.py
+++ b/custom_components/nl_weather/binary_sensor.py
@@ -6,11 +6,13 @@ from homeassistant.config_entries import ConfigSubentry
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from typing import Any
 
-from .const import Alert
+from .const import Alert, ATTR_WEATHER_SOLAR_RADIATION, ATTR_WEATHER_SUNSHINE, PARAMETER_ATTRIBUTE_MAP
 from . import DOMAIN
 from .coordinator import (
     NLWeatherConfigEntry,
+    NLWeatherEDRCoordinator,
     NLWeatherNowcastCoordinator,
     NLWeatherUpdateCoordinator,
 )
@@ -28,12 +30,14 @@ async def async_setup_entry(
         nowcast_coordinator = config_entry.runtime_data.nowcast_coordinators[
             subentry_id
         ]
+        edr_coordinator = config_entry.runtime_data.edr_coordinators[subentry_id]
         async_add_entities(
             [
                 NLWeatherAlertActiveSensor(app_coordinator, config_entry, subentry),
                 NLWeatherPrecipitationNowcastSensor(
                     nowcast_coordinator, config_entry, subentry
                 ),
+                NLWeatherSunSensor(edr_coordinator, config_entry, subentry),
             ],
             config_subentry_id=subentry_id,
         )
@@ -103,7 +107,53 @@ class NLWeatherPrecipitationNowcastSensor(
             return False
 
         now = utcnow()
-        return any(
+            return any(
             p["datetime"] > now and p["precipitation"] > 0
             for p in self.coordinator.data
         )
+
+
+class NLWeatherSunSensor(
+    CoordinatorEntity[NLWeatherEDRCoordinator], BinarySensorEntity
+):
+    def __init__(
+        self,
+        coordinator: NLWeatherEDRCoordinator,
+        config_entry: NLWeatherConfigEntry,
+        subentry: ConfigSubentry,
+    ) -> None:
+        super().__init__(coordinator)
+
+        self._attr_unique_id = (
+            f"{config_entry.entry_id}_{subentry.subentry_id}_sun"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{config_entry.entry_id}_{subentry.subentry_id}")},
+        )
+        self._attr_has_entity_name = True
+        self.entity_description = BinarySensorEntityDescription(
+            key="sun",
+            icon="mdi:weather-sunny",
+            translation_key="sun",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        if self.coordinator.data is None:
+            return None
+        solar = self.coordinator.data.get("params", {}).get(
+            PARAMETER_ATTRIBUTE_MAP[ATTR_WEATHER_SOLAR_RADIATION]
+        )
+        if solar is None:
+            return None
+        return solar > 50
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        if self.coordinator.data is None:
+            return None
+        params = self.coordinator.data.get("params", {})
+        solar = params.get(PARAMETER_ATTRIBUTE_MAP[ATTR_WEATHER_SOLAR_RADIATION])
+        sunshine = params.get(PARAMETER_ATTRIBUTE_MAP[ATTR_WEATHER_SUNSHINE])
+        sunshine_pct = round(sunshine * 10) if sunshine is not None else None
+        return {"solar_radiation": solar, "sunshine_pct": sunshine_pct}

--- a/custom_components/nl_weather/manifest.json
+++ b/custom_components/nl_weather/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/PaulVanSchayck/ha-nl-weather",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/PaulVanSchayck/ha-nl-weather/issues",
-  "requirements": ["aiomqtt~=2.5.0", "pyproj~=3.7.2"],
+  "requirements": ["aiomqtt~=2.5.0", "pyproj~=3.7.2", "pythermalcomfort~=2.0.0"],
   "version": "0.11.1"
 }

--- a/custom_components/nl_weather/sensor.py
+++ b/custom_components/nl_weather/sensor.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pythermalcomfort.models import utci as _calc_utci
 
 from . import DOMAIN
 from .const import (
@@ -62,6 +63,9 @@ class AlertSensorDescription(SensorEntityDescription):
 @dataclass(frozen=True)
 class ObservationSensorDescription(SensorEntityDescription):
     value_fn: Callable[[dict[str, Any]], Any] | None = field(default=None, repr=False)
+    state_attributes_fn: Callable[[dict[str, Any]], dict[str, Any] | None] | None = field(
+        default=None, repr=False
+    )
 
 
 @dataclass(frozen=True)
@@ -110,6 +114,51 @@ def _get_wind_direction_cardinal(data: dict[str, Any]) -> str | None:
     return VALID_CARDINAL_DIRECTIONS[index]
 
 
+def _wind_speed_to_beaufort(v_ms: float) -> int | None:
+    if v_ms < 0.3:
+        return 0
+    return int(round((v_ms / 0.836) ** (2 / 3)))
+
+
+def _get_wind_speed_attributes(
+    data: dict[str, Any],
+) -> dict[str, Any] | None:
+    wind_ms = _get_observation_param(data, ATTR_WEATHER_WIND_SPEED)
+    if wind_ms is None:
+        return None
+    return {"beaufort": _wind_speed_to_beaufort(wind_ms)}
+
+
+def _estimate_mrt(
+    temp_c: float, solar_wm2: float, cloud_okta: float | None
+) -> float:
+    if solar_wm2 <= 10:
+        return temp_c
+    if cloud_okta is not None:
+        if cloud_okta == 9:
+            cloud_pct = 100.0
+        else:
+            cloud_pct = cloud_okta / 8.0 * 100.0
+        cloud_frac = max(0.0, min(1.0, cloud_pct / 100.0))
+    else:
+        cloud_frac = 0.5
+    effective_solar = solar_wm2 * (1.0 - 0.5 * cloud_frac)
+    return temp_c + effective_solar * 0.02
+
+
+def _get_feels_like(data: dict[str, Any]) -> float | None:
+    temp = _get_observation_param(data, ATTR_WEATHER_TEMPERATURE)
+    wind_ms = _get_observation_param(data, ATTR_WEATHER_WIND_SPEED)
+    humidity = _get_observation_param(data, ATTR_WEATHER_HUMIDITY)
+    solar = _get_observation_param(data, ATTR_WEATHER_SOLAR_RADIATION)
+    cloud = _get_observation_param(data, ATTR_WEATHER_CLOUD_COVERAGE)
+    if None in (temp, wind_ms, humidity):
+        return None
+    mrt = _estimate_mrt(temp, solar or 0, cloud)
+    v = max(wind_ms, 0.5)
+    return round(float(_calc_utci(tdb=temp, tr=mrt, v=v, rh=humidity)), 1)
+
+
 def _get_forecast_temperature(
     day_index: int, temp_key: str
 ) -> Callable[[dict[str, Any]], Any]:
@@ -121,6 +170,21 @@ def _get_forecast_temperature(
     def _fn(data: dict[str, Any]) -> Any:
         try:
             return data["daily"]["forecast"][day_index]["temperature"][temp_key]
+        except (KeyError, IndexError, TypeError):
+            return None
+
+    return _fn
+
+
+def _get_forecast_precipitation_chance(
+    day_index: int,
+) -> Callable[[dict[str, Any]], Any]:
+    def _fn(data: dict[str, Any]) -> Any:
+        try:
+            chance = data["daily"]["forecast"][day_index]["precipitation"]["chance"]
+            if chance is None:
+                return None
+            return round(chance * 100)
         except (KeyError, IndexError, TypeError):
             return None
 
@@ -190,6 +254,7 @@ OBSERVATION_SENSOR_DESCRIPTIONS: list[ObservationSensorDescription] = [
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
         suggested_display_precision=1,
         value_fn=lambda data: _get_observation_param(data, ATTR_WEATHER_WIND_SPEED),
+        state_attributes_fn=_get_wind_speed_attributes,
     ),
     ObservationSensorDescription(
         key="wind_gust",
@@ -311,6 +376,15 @@ OBSERVATION_SENSOR_DESCRIPTIONS: list[ObservationSensorDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.get("datetime"),
     ),
+    ObservationSensorDescription(
+        key="feels_like",
+        translation_key="observations_feels_like",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=1,
+        value_fn=_get_feels_like,
+    ),
 ]
 
 
@@ -342,6 +416,22 @@ FORECAST_SENSOR_DESCRIPTIONS: list[ForecastSensorDescription] = [
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=_get_forecast_temperature(1, "min"),
+    ),
+    ForecastSensorDescription(
+        key="precipitation_chance_today",
+        translation_key="forecast_precipitation_chance_today",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:weather-rainy",
+        value_fn=_get_forecast_precipitation_chance(0),
+    ),
+    ForecastSensorDescription(
+        key="precipitation_chance_tomorrow",
+        translation_key="forecast_precipitation_chance_tomorrow",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:weather-rainy",
+        value_fn=_get_forecast_precipitation_chance(1),
     ),
     ForecastSensorDescription(
         key="heat_force_index",
@@ -433,12 +523,19 @@ class NLObservationSensor(CoordinatorEntity[NLWeatherEDRCoordinator], SensorEnti
         self._attr_has_entity_name = True
         self._subentry_id = subentry.subentry_id
         self._value_fn = desc.value_fn
+        self._state_attributes_fn = desc.state_attributes_fn
 
     @property
     def native_value(self):
         if self.coordinator.data is None:
             return None
         return self._value_fn(self.coordinator.data)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        if self.coordinator.data is None or self._state_attributes_fn is None:
+            return None
+        return self._state_attributes_fn(self.coordinator.data)
 
 
 class NLForecastSensor(CoordinatorEntity[NLWeatherUpdateCoordinator], SensorEntity):

--- a/custom_components/nl_weather/translations/en.json
+++ b/custom_components/nl_weather/translations/en.json
@@ -77,6 +77,9 @@
       "observations_temperature_soil": {
         "name": "Soil temperature (-10 cm)"
       },
+      "observations_feels_like": {
+        "name": "Feels like"
+      },
       "observations_wind_direction": {
         "name": "Wind direction (degrees)"
       },
@@ -113,6 +116,12 @@
       "forecast_tomorrow_low": {
         "name": "Min temperature tomorrow"
       },
+      "forecast_precipitation_chance_today": {
+        "name": "Precipitation chance today"
+      },
+      "forecast_precipitation_chance_tomorrow": {
+        "name": "Precipitation chance tomorrow"
+      },
       "heat_force_index": {
         "name": "Heat force"
       },
@@ -126,6 +135,9 @@
       },
       "precipitation_nowcast": {
         "name": "Precipitation forecasted"
+      },
+      "sun": {
+        "name": "Sun"
       }
     }
   },

--- a/custom_components/nl_weather/translations/nl.json
+++ b/custom_components/nl_weather/translations/nl.json
@@ -77,6 +77,9 @@
       "observations_temperature_soil": {
         "name": "Grondtemperatuur (-10 cm)"
       },
+      "observations_feels_like": {
+        "name": "Gevoelstemperatuur"
+      },
       "observations_wind_direction": {
         "name": "Windrichting (graden)"
       },
@@ -113,6 +116,12 @@
       "forecast_tomorrow_low": {
         "name": "Min temperatuur morgen"
       },
+      "forecast_precipitation_chance_today": {
+        "name": "Neerslagkans vandaag"
+      },
+      "forecast_precipitation_chance_tomorrow": {
+        "name": "Neerslagkans morgen"
+      },
       "heat_force_index": {
         "name": "Hittekracht"
       },
@@ -126,6 +135,9 @@
       },
       "precipitation_nowcast": {
         "name": "Neerslag verwacht"
+      },
+      "sun": {
+        "name": "Zon"
       }
     }
   },


### PR DESCRIPTION
Adds a `feels_like` observation sensor that computes the Universal Thermal Climate Index (UTCI) as the feels-like/gevoelstemperatuur.

- Uses `pythermalcomfort` library for the official UTCI polynomial
- Estimates Mean Radiant Temperature (MRT) from solar radiation + cloud coverage
- Falls back to None when temperature/wind/humidity observations are unavailable
- Translations: EN "Feels like", NL "Gevoelstemperatuur"
- Dependency added: `pythermalcomfort~=2.0.0`